### PR TITLE
update to latest aws instance type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ service-chain
 # Editors
 **/.*.sw*
 .idea
+.DS_Store
 
 # Virtualenvs
 .env

--- a/conf.dynamo.json
+++ b/conf.dynamo.json
@@ -10,7 +10,8 @@
       },
       "keyName":"aws.key",
       "subnet": "subnet-3f123456789012345",
-      "zone":"ap-northeast-2a"
+      "zone":"ap-northeast-2a",
+      "storageType": "gp3"
     }
   },
   "source":{
@@ -36,7 +37,7 @@
       "dockerBaseImage":"klaytn/build_base:1.1-go1.15.7-solc0.4.24",
       "git":{
         "ref":"git@github.com:klaytn/klaytn-load-tester.git",
-        "branch":"master"
+        "branch":"main"
       }
     },
     "locustSC":{
@@ -63,12 +64,12 @@
   "deploy":{
     "CN": {
       "aws":{
-        "numNodes":4,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "numNodes":1,
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
         "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"],
         "_imageIds":[
           "ami-0454bb2fefc7de534",
           "ami-0750a20e9959e44ff",
@@ -98,12 +99,12 @@
     },
     "PN": {
       "aws":{
-        "numNodes":4,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "numNodes":1,
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -113,12 +114,12 @@
     },
     "EN": {
       "aws":{
-        "numNodes":4,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "numNodes":1,
+        "instanceType":"r6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":[
         " --db.dynamodb.table-name anonymous-tag-en0 ",
@@ -145,10 +146,10 @@
       "aws": {
         "numNodes":1,
         "instanceType":"t3.small",
-        "userName":"ubuntu",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "overrideOptions":{
         "KEY_PATH":"~/klaytn/keys/nodekey",
@@ -162,10 +163,10 @@
       "aws": {
         "numNodes":1,
         "instanceType":"t3.small",
-        "userName":"ubuntu",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "overrideOptions":{
         "KEY_PATH":"~/klaytn/keys/nodekey",
@@ -178,7 +179,7 @@
       "bridges": {
         "mainBridge": "EN",
         "subBridge": "SCN",
-        "num": 1
+        "num": 0
       },
       "anchoring": {
         "SC_ANCHORING": 1,
@@ -192,11 +193,11 @@
     "SCN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -208,11 +209,11 @@
     "SPN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -224,11 +225,11 @@
     "SEN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"r6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -242,11 +243,11 @@
       "prometheusPort":61001,
       "aws": {
         "numNodes":1,
-        "imageId":"ami-033a6a056910d1137",
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":8},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":8, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
     "locustMaster":{
@@ -279,11 +280,11 @@
       },
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
     "locustSlave": {
@@ -292,6 +293,7 @@
       "_endpoints":["CN", "PN", "EN", "http://{IP}:{Port}"],
       "endpoints":["EN"],
       "RPS": 100,
+      "_overrideCharge": 100,
       "testcases":[
         "analyticTx",
         "analyticQueryLargestAccBalTx",
@@ -344,22 +346,22 @@
       "_overrideKeys":[],
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
     "locustSCMaster":{
       "enabled":false,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
     "locustSCSlave": {
@@ -375,23 +377,23 @@
       "slavesPerNode":1,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
-    "graylog": {
-      "enabled": false,
-      "inputPort": 5555,
-      "aws": {
-        "numNodes": 1,
-        "instanceType": "m5.large",
-        "imageId": "ami-0454bb2fefc7de534",
-        "storage": { "DeviceName": "/dev/sda1", "VolumeSize": 50},
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "userName": "ubuntu"
+    "graylog":{
+      "enabled":false,
+      "inputPort":5555,
+      "aws":{
+        "numNodes":1,
+        "instanceType":"m6i.large",
+        "imageId":"ami-0454bb2fefc7de534",
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     }
   },

--- a/conf.enonly.lumberjack.json
+++ b/conf.enonly.lumberjack.json
@@ -10,7 +10,8 @@
       },
       "keyName":"aws.key",
       "subnet": "subnet-3f123456789012345",
-      "zone":"ap-northeast-2a"
+      "zone":"ap-northeast-2a",
+      "storageType": "gp3"
     }
   },
   "source":{
@@ -37,7 +38,7 @@
       "dockerBaseImage":"klaytn/build_base:1.1-go1.15.7-solc0.4.24",
       "git":{
         "ref":"git@github.com:klaytn/klaytn-load-tester.git",
-        "branch":"master"
+        "branch":"main"
       }
     },
     "locustSC":{
@@ -65,11 +66,11 @@
     "CN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
         "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"],
         "_imageIds":[
           "ami-0454bb2fefc7de534",
           "ami-0750a20e9959e44ff",
@@ -100,11 +101,11 @@
     "PN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -115,11 +116,11 @@
     "EN": {
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "securityGroup":["sg-0abcdefghijklmnop"],
+        "instanceType":"r6i.large",
         "imageId":"ami-0e020234234283491",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":4000},
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -137,9 +138,9 @@
       "aws": {
         "numNodes":1,
         "instanceType":"t3.small",
-        "userName":"ubuntu",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "overrideOptions":{
@@ -154,9 +155,9 @@
       "aws": {
         "numNodes":1,
         "instanceType":"t3.small",
-        "userName":"ubuntu",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "overrideOptions":{
@@ -170,7 +171,7 @@
       "bridges": {
         "mainBridge": "EN",
         "subBridge": "SCN",
-        "num": 1
+        "num": 0
       },
       "anchoring": {
         "SC_ANCHORING": 1,
@@ -184,10 +185,10 @@
     "SCN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
@@ -200,10 +201,10 @@
     "SPN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
@@ -216,10 +217,10 @@
     "SEN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"r6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
@@ -234,11 +235,11 @@
       "prometheusPort":61001,
       "aws": {
         "numNodes":1,
-        "imageId":"ami-033a6a056910d1137",
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":8},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":8, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "locustMaster":{
@@ -271,11 +272,11 @@
       },
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "locustSlave": {
@@ -337,22 +338,22 @@
       "_overrideKeys":[],
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "locustSCMaster":{
       "enabled":false,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "locustSCSlave": {
@@ -368,23 +369,23 @@
       "slavesPerNode":1,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
-    "graylog": {
-      "enabled": false,
-      "inputPort": 5555,
-      "aws": {
-        "numNodes": 1,
-        "instanceType": "m5.large",
-        "imageId": "ami-0454bb2fefc7de534",
-        "storage": { "DeviceName": "/dev/sda1", "VolumeSize": 50},
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "userName": "ubuntu"
+    "graylog":{
+      "enabled":false,
+      "inputPort":5555,
+      "aws":{
+        "numNodes":1,
+        "instanceType":"m6i.large",
+        "imageId":"ami-0454bb2fefc7de534",
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     }
   },

--- a/conf.enonly.sync.json
+++ b/conf.enonly.sync.json
@@ -10,7 +10,8 @@
       },
       "keyName":"aws.key",
       "subnet": "subnet-3f123456789012345",
-      "zone":"ap-northeast-2a"
+      "zone":"ap-northeast-2a",
+      "storageType": "gp3"
     }
   },
   "source":{
@@ -36,7 +37,7 @@
       "dockerBaseImage":"klaytn/build_base:1.1-go1.15.7-solc0.4.24",
       "git":{
         "ref":"git@github.com:klaytn/klaytn-load-tester.git",
-        "branch":"master"
+        "branch":"main"
       }
     },
     "locustSC":{
@@ -64,11 +65,11 @@
     "CN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
         "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"],
         "_imageIds":[
           "ami-0454bb2fefc7de534",
           "ami-0750a20e9959e44ff",
@@ -99,11 +100,11 @@
     "PN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -112,16 +113,16 @@
       }
     },
     "EN": {
-      "aws": {
+      "aws":{
         "numNodes":2,
-        "instanceType":"m5.2xlarge",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "instanceType":"r6i.2xlarge",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName": "/dev/sda1","VolumeSize": 4000},
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
-      "overrideOptions": [{
+      "overrideOptions":[{
         "NETWORK":"baobab",
         "NETWORK_ID":"",
         "RPC_PORT":8551,
@@ -143,9 +144,9 @@
       "aws": {
         "numNodes":1,
         "instanceType":"t3.small",
-        "userName":"ubuntu",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "overrideOptions":{
@@ -160,9 +161,9 @@
       "aws": {
         "numNodes":1,
         "instanceType":"t3.small",
-        "userName":"ubuntu",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "overrideOptions":{
@@ -176,7 +177,7 @@
       "bridges": {
         "mainBridge": "EN",
         "subBridge": "SCN",
-        "num": 1
+        "num": 0
       },
       "anchoring": {
         "SC_ANCHORING": 1,
@@ -190,10 +191,10 @@
     "SCN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
@@ -206,10 +207,10 @@
     "SPN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
@@ -222,10 +223,10 @@
     "SEN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"r6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
         "securityGroup": ["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
@@ -240,11 +241,11 @@
       "prometheusPort":61001,
       "aws": {
         "numNodes":1,
-        "imageId":"ami-033a6a056910d1137",
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":8},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":8, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "locustMaster":{
@@ -277,11 +278,11 @@
       },
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "locustSlave": {
@@ -343,22 +344,22 @@
       "_overrideKeys":[],
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "locustSCMaster":{
       "enabled":false,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "locustSCSlave": {
@@ -374,11 +375,11 @@
       "slavesPerNode":1,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     },
     "graylog":{
@@ -386,11 +387,11 @@
       "inputPort":5555,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
+        "securityGroup": ["sg-0abcdefghijklmnop"]
       }
     }
   },

--- a/conf.template.json
+++ b/conf.template.json
@@ -6,11 +6,12 @@
       "tags": {
         "User":"anonymousTag",
         "Project": "klaytn",
-        "Team": "unknown"
+        "Team": "klaytn"
       },
       "keyName":"aws.key",
       "subnet": "subnet-3f123456789012345",
-      "zone":"ap-northeast-2a"
+      "zone":"ap-northeast-2a",
+      "storageType": "gp3"
     }
   },
   "source":{
@@ -36,7 +37,7 @@
       "dockerBaseImage":"klaytn/build_base:1.1-go1.15.7-solc0.4.24",
       "git":{
         "ref":"git@github.com:klaytn/klaytn-load-tester.git",
-        "branch":"master"
+        "branch":"main"
       }
     },
     "locustSC":{
@@ -64,11 +65,11 @@
     "CN": {
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
         "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"],
         "_imageIds":[
           "ami-0454bb2fefc7de534",
           "ami-0750a20e9959e44ff",
@@ -99,11 +100,11 @@
     "PN": {
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -114,17 +115,17 @@
     "EN": {
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
+        "instanceType":"r6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "userName":"ubuntu"
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
-        "_NETWORK": "baobab",
-        "_NETWORK_ID": "",
-        "_NO_DISCOVER": "0",
+        "_NETWORK":"baobab",
+        "_NETWORK_ID":"",
+        "_NO_DISCOVER":"0",
         "RPC_PORT":8551,
         "RPC_API":"klay,personal",
         "DATA_DIR":"~/klaytn/data",
@@ -137,10 +138,10 @@
       "aws": {
         "numNodes":1,
         "instanceType":"t3.small",
-        "userName":"ubuntu",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "overrideOptions":{
         "KEY_PATH":"~/klaytn/keys/nodekey",
@@ -154,10 +155,10 @@
       "aws": {
         "numNodes":1,
         "instanceType":"t3.small",
-        "userName":"ubuntu",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":50},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "overrideOptions":{
         "KEY_PATH":"~/klaytn/keys/nodekey",
@@ -170,7 +171,7 @@
       "bridges": {
         "mainBridge": "EN",
         "subBridge": "SCN",
-        "num": 1
+        "num": 0
       },
       "anchoring": {
         "SC_ANCHORING": 1,
@@ -184,11 +185,11 @@
     "SCN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -200,11 +201,11 @@
     "SPN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"m6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -216,11 +217,11 @@
     "SEN": {
       "aws":{
         "numNodes":0,
-        "instanceType":"m5.large",
-        "userName":"ubuntu",
+        "instanceType":"r6i.large",
         "imageId":"ami-0454bb2fefc7de534",
-        "storage":{"DeviceName":"/dev/sda1","VolumeSize":150},
-        "securityGroup": ["sg-0abcdefghijklmnop"]
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":150, "Iops":9000, "Throughput":500},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       },
       "initOption":"",
       "overrideOptions":{
@@ -234,11 +235,11 @@
       "prometheusPort":61001,
       "aws": {
         "numNodes":1,
-        "imageId":"ami-033a6a056910d1137",
-        "instanceType":"m5.large",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":8},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":8, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
     "locustMaster":{
@@ -271,11 +272,11 @@
       },
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
     "locustSlave": {
@@ -284,7 +285,7 @@
       "_endpoints":["CN", "PN", "EN", "http://{IP}:{Port}"],
       "endpoints":["EN"],
       "RPS": 100,
-      "_overrideCharge": 100, 
+      "_overrideCharge": 100,
       "testcases":[
         "analyticTx",
         "analyticQueryLargestAccBalTx",
@@ -337,22 +338,22 @@
       "_overrideKeys":[],
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
     "locustSCMaster":{
       "enabled":false,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
     "locustSCSlave": {
@@ -368,23 +369,23 @@
       "slavesPerNode":1,
       "aws":{
         "numNodes":1,
-        "instanceType":"m5.large",
-        "imageId":"ami-033a6a056910d1137",
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "storage":{"DeviceName":"/dev/xvda","VolumeSize":16},
-        "userName":"ec2-user"
+        "instanceType":"m6i.large",
+        "imageId":"ami-0676d41f079015f32",
+        "storage":{"DeviceName":"/dev/xvda", "VolumeSize":16, "Iops":3000, "Throughput":250},
+        "userName":"ec2-user",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     },
-    "graylog": {
-      "enabled": false,
-      "inputPort": 5555,
-      "aws": {
-        "numNodes": 1,
-        "instanceType": "m5.large",
-        "imageId": "ami-0454bb2fefc7de534",
-        "storage": { "DeviceName": "/dev/sda1", "VolumeSize": 50},
-        "securityGroup": ["sg-0abcdefghijklmnop"],
-        "userName": "ubuntu"
+    "graylog":{
+      "enabled":false,
+      "inputPort":5555,
+      "aws":{
+        "numNodes":1,
+        "instanceType":"m6i.large",
+        "imageId":"ami-0454bb2fefc7de534",
+        "storage":{"DeviceName":"/dev/sda1", "VolumeSize":50, "Iops":3000, "Throughput":250},
+        "userName":"ubuntu",
+        "securityGroup":["sg-0abcdefghijklmnop"]
       }
     }
   },

--- a/plib/AWSInstanceManager.py
+++ b/plib/AWSInstanceManager.py
@@ -443,7 +443,9 @@ class AWSInstanceManager:
 					'Ebs': {
 						'Encrypted': False,
 						'DeleteOnTermination': True,
-						'VolumeType': 'gp2',
+						'VolumeType': self.userInfo["aws"]["storageType"],
+						'Iops': self.awsConf["storage"]["Iops"],
+						'Throughput': self.awsConf["storage"]["Throughput"],
 						'VolumeSize': self.awsConf["storage"]["VolumeSize"] if "VolumeSize" in self.awsConf["storage"] else 1000, # 1T in default
 					}
 				}
@@ -1132,7 +1134,7 @@ class AWSInstanceManager:
 		# if the library is not installed, install the library.
 		if "locust" in command:
 			target_library = "locust"
-			install_cmd = "sudo yum install python3-devel gcc -y > /dev/null \
+			install_cmd = "sudo yum install python3 python3-pip gcc -y > /dev/null \
 			&& pip3 install --user web3 locust==1.2.3 > /dev/null"
 		elif "prometheus" in command:
 			target_library = "prometheus"

--- a/plib/KlaytnCmd.py
+++ b/plib/KlaytnCmd.py
@@ -81,7 +81,7 @@ class KlaytnCmd:
 				flatten_build_args = "--build-arg " + " --build-arg ".join(build_args)
 			print("using base docker image: ", dockerBaseImage)
 			print("docker build %s --no-cache -t %s ." % (flatten_build_args, dockerImageTag))
-			ExecuteShell("cd %s && git checkout master && git fetch -f %s %s && git checkout %s && git checkout -B build && docker build %s --no-cache -t %s ." %
+			ExecuteShell("cd %s && git checkout dev && git fetch -f %s %s && git checkout %s && git checkout -B build && docker build %s --no-cache -t %s ." %
 					(klaytnDir, ref, branch, branch, flatten_build_args, dockerImageTag))
 
 	def extract(self, args):

--- a/plib/LocustSCCmd.py
+++ b/plib/LocustSCCmd.py
@@ -49,8 +49,8 @@ class LocustSCCmd:
 
 		if os.path.exists("%s/%s" % (locustDir, klaytnDir)) == False:
 			ExecuteShell("cd %s && git clone %s" % (locustDir, klaytnRef))
-		ExecuteShell("cd %s/%s && git checkout master && git fetch -f %s %s && git checkout %s && git checkout -B build" % (locustDir, klaytnDir, klaytnRef, klaytnBranch, klaytnBranch))
-		ExecuteShell("cd %s && git checkout master && git fetch -f %s %s && git checkout %s  && git checkout -B build  && docker build -t %s ." % (locustDir, ref, branch, branch, dockerImageTag))
+		ExecuteShell("cd %s/%s && git checkout dev && git fetch -f %s %s && git checkout %s && git checkout -B build" % (locustDir, klaytnDir, klaytnRef, klaytnBranch, klaytnBranch))
+		ExecuteShell("cd %s && git checkout main && git fetch -f %s %s && git checkout %s  && git checkout -B build  && docker build -t %s ." % (locustDir, ref, branch, branch, dockerImageTag))
 
 	def extract(self, args):
 		jsonConf = LoadConfig(args.conf)


### PR DESCRIPTION
Update the aws instance type defined at configuration json files to latest aws instance type (m5 -> m6)
In addition, make the locust slave binary (klayslave) works at linux/amd64 instance. In the future, it would be compatible with every os type.

I have tested with 1cn/1pn/1en private network.